### PR TITLE
Suppress ProfileFormatter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,22 +16,21 @@ jobs:
       matrix:
         ci_node_total: [4]
         ci_node_index: [0, 1, 2, 3]
-    env:
-      SELECTIVE_API_KEY: ${{ secrets.SELECTIVE_API_KEY }}
-      SELECTIVE_RUN_ID: ${{ github.run_id }}
-      SELECTIVE_RUN_ATTEMPT: ${{ github.run_attempt }}
-      SELECTIVE_PR_TITLE: ${{ github.event.pull_request.title }}
-      SELECTIVE_RUNNER_ID: ${{ matrix.ci_node_index }}
-      CLONE_PAT: ${{ secrets.CLONE_PAT }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2.2"
           bundler-cache: true
+
+      - name: Setup Selective
+        uses: selectiveci/setup-selective@v1
+        with:
+          api-key: ${{ secrets.SELECTIVE_API_KEY }}
+          runner-id: ${{ matrix.ci_node_index }}
 
       - name: Run the default task
         run: bundle exec selective rspec

--- a/.github/workflows/test_all_the_things.yml
+++ b/.github/workflows/test_all_the_things.yml
@@ -26,17 +26,10 @@ jobs:
         runners: [1, 2]
 
     env:
-      SELECTIVE_API_KEY: ${{ secrets.SELECTIVE_API_KEY }}
       BUNDLE_GEMFILE: ${{ matrix.gemfiles }}
-      SELECTIVE_HOST: wss://app.selective.ci
-      SELECTIVE_RUN_ID: ${{ github.run_id }}-${{ matrix.ruby }}-${{ matrix.gemfiles }}
-      SELECTIVE_RUN_ATTEMPT: ${{ github.run_attempt }}
-      SELECTIVE_PR_TITLE: ${{ github.event.pull_request.title }}
-      SELECTIVE_RUNNER_ID: ${{ matrix.ruby }}-${{ matrix.gemfiles }}-${{ matrix.runners }}
-      CLONE_PAT: ${{ secrets.CLONE_PAT }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -47,5 +40,13 @@ jobs:
       - name: Download Transport
         run: bin/get_transport
 
+      - name: Setup Selective
+        uses: selectiveci/setup-selective@v1
+        with:
+          api-key: ${{ secrets.SELECTIVE_API_KEY }}
+          runner-id: ${{ matrix.ruby }}-${{ matrix.gemfiles }}-${{ matrix.runners }}
+
       - name: Run the default task
+        env:
+          SELECTIVE_RUN_ID: ${{ github.run_id }}-${{ matrix.ruby }}-${{ matrix.gemfiles }}
         run: bundle exec selective rspec

--- a/.github/workflows/test_all_the_things.yml
+++ b/.github/workflows/test_all_the_things.yml
@@ -37,9 +37,6 @@ jobs:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
 
-      - name: Download Transport
-        run: bin/get_transport
-
       - name: Setup Selective
         uses: selectiveci/setup-selective@v1
         with:

--- a/.github/workflows/test_all_the_things.yml
+++ b/.github/workflows/test_all_the_things.yml
@@ -41,7 +41,7 @@ jobs:
         uses: selectiveci/setup-selective@v1
         with:
           api-key: ${{ secrets.SELECTIVE_API_KEY }}
-          runner-id: ${{ matrix.ruby }}-${{ matrix.gemfiles }}-${{ matrix.runners }}
+          runner-id: ${{ matrix.runners }}
 
       - name: Run the default task
         env:

--- a/gemfiles/rspec_3.10.gemfile
+++ b/gemfiles/rspec_3.10.gemfile
@@ -9,5 +9,6 @@ gem "standard", "~> 1.19.1"
 gem "irb"
 gem "rspec_junit_formatter"
 gem "appraisal", "~> 2.5"
+gem "selective-ruby-core", git: "https://github.com/selectiveci/selective-ruby-core.git"
 
 gemspec path: "../"

--- a/gemfiles/rspec_3.11.gemfile
+++ b/gemfiles/rspec_3.11.gemfile
@@ -9,5 +9,6 @@ gem "standard", "~> 1.19.1"
 gem "irb"
 gem "rspec_junit_formatter"
 gem "appraisal", "~> 2.5"
+gem "selective-ruby-core", git: "https://github.com/selectiveci/selective-ruby-core.git"
 
 gemspec path: "../"

--- a/gemfiles/rspec_3.12.gemfile
+++ b/gemfiles/rspec_3.12.gemfile
@@ -9,5 +9,6 @@ gem "standard", "~> 1.19.1"
 gem "irb"
 gem "rspec_junit_formatter"
 gem "appraisal", "~> 2.5"
+gem "selective-ruby-core", git: "https://github.com/selectiveci/selective-ruby-core.git"
 
 gemspec path: "../"

--- a/gemfiles/rspec_3.8.gemfile
+++ b/gemfiles/rspec_3.8.gemfile
@@ -9,5 +9,6 @@ gem "standard", "~> 1.19.1"
 gem "irb"
 gem "rspec_junit_formatter"
 gem "appraisal", "~> 2.5"
+gem "selective-ruby-core", git: "https://github.com/selectiveci/selective-ruby-core.git"
 
 gemspec path: "../"

--- a/gemfiles/rspec_3.9.gemfile
+++ b/gemfiles/rspec_3.9.gemfile
@@ -9,5 +9,6 @@ gem "standard", "~> 1.19.1"
 gem "irb"
 gem "rspec_junit_formatter"
 gem "appraisal", "~> 2.5"
+gem "selective-ruby-core", git: "https://github.com/selectiveci/selective-ruby-core.git"
 
 gemspec path: "../"

--- a/lib/selective/ruby/rspec/monkeypatches.rb
+++ b/lib/selective/ruby/rspec/monkeypatches.rb
@@ -5,7 +5,8 @@ module Selective
         MAP = {
           "BaseTextFormatter" => [:message, :dump_pending, :seed, :close],
           "ProgressFormatter" => [:start_dump],
-          "DocumentationFormatter" => [:message]
+          "DocumentationFormatter" => [:message],
+          "ProfileFormatter" => [:dump_profile]
         }
 
         MAP.each do |module_name, methods|


### PR DESCRIPTION
Setting ::RSpec.configuration.profile_examples = nil isn't enough when a user specifies --profile at the rspec command line. This change ensures that the ProfileFormatter never generates a report.