### PR TITLE
Support nested before/after :all hooks

### DIFF
--- a/lib/selective/ruby/rspec/monkeypatches.rb
+++ b/lib/selective/ruby/rspec/monkeypatches.rb
@@ -139,6 +139,17 @@ module Selective
           end
         end
 
+        module Hooks
+          hooks = %i(before prepend_before after append_after)
+
+          hooks.each do |hook|
+            define_method(hook) do |*args, &block|
+              args = args.map { |a| a == :all ? :each : a }
+              super(*args, &block)
+            end
+          end
+        end
+
         def self.apply
           ::RSpec::Support.require_rspec_core("formatters/base_text_formatter")
 
@@ -149,6 +160,7 @@ module Selective
           end
 
           ::RSpec.singleton_class.prepend(RSpec)
+          ::RSpec::Core::Hooks.prepend(Hooks)
           ::RSpec::Core::Reporter.prepend(Reporter)
           ::RSpec::Core::Configuration.prepend(Configuration)
           ::RSpec::Core::World.prepend(World)

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe "Before/after hooks" do
+  before(:all) { @outer_before_all = true }
+  before(:each) { @outer_before_each = true }
+
+  after(:all) { expect(@outer_after_all).to eq(true) }
+  after(:each) { expect(@outer_after_each).to eq(true) }
+
+  it 'runs in outter context' do
+    expect(@outer_before_all).to eq(true)
+    expect(@outer_before_each).to eq(true)
+    @outer_after_all = true
+    @outer_after_each = true
+  end
+
+  context 'when defined in a nested context' do
+    before(:all) { @inner_before_all = true }
+    before(:each) { @inner_before_each = true }
+
+    after(:all) { expect(@inner_after_all).to eq(true) }
+    after(:each) { expect(@inner_after_each).to eq(true) }
+
+    it 'runs hooks in innter context' do
+      expect(@inner_before_all).to eq(true)
+      expect(@inner_before_each).to eq(true)
+      @inner_after_all = true
+      @inner_after_each = true
+      @outer_after_all = true
+      @outer_after_each = true
+    end
+  end
+end


### PR DESCRIPTION
Because selective splits by example before all hooks must be run as before each hooks. We got this working recently but it was not working when defined in a nested context. This commit fixes that by explicitly changing before all hooks to before each hooks.

This is a behavior we may enable with an explicit flag or configuration option in the future. For now it is enabled by default.