### PR TITLE
Bugfix for zeitwerk eager loading

### DIFF
--- a/lib/selective-ruby-rspec.rb
+++ b/lib/selective-ruby-rspec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "zeitwerk"
+require "rspec/core"
 
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.inflector.inflect("rspec" => "RSpec")

--- a/lib/selective-ruby-rspec.rb
+++ b/lib/selective-ruby-rspec.rb
@@ -6,6 +6,7 @@ require "rspec/core"
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.inflector.inflect("rspec" => "RSpec")
 loader.ignore("#{__dir__}/selective-ruby-rspec.rb")
+loader.ignore("#{__dir__}/selective/ruby/rspec/version.rb")
 loader.setup
 
 require "selective-ruby-core"

--- a/lib/selective/ruby/rspec/runner_wrapper.rb
+++ b/lib/selective/ruby/rspec/runner_wrapper.rb
@@ -12,8 +12,6 @@ module Selective
         DEFAULT_SPEC_PATH = "./spec"
 
         def initialize(args)
-          require "rspec/core"
-
           Selective::Ruby::RSpec::Monkeypatches.apply
           apply_rspec_configuration
 


### PR DESCRIPTION
The version file doesn't define a Version constant. It defines a VERSION constant, which is typical for a rubygem. To avoid this issue we're explicitly ignoring the version file.

> expected file lib/selective/ruby/core/version.rb to define constant
> Selective::Ruby::RSpec::Version, but didn't

We've also moved the rspec/core require into the gem entrypoint, which fixed another eagerloading bug.
