### PR TITLE
Explicitly require version file

### DIFF
--- a/lib/selective-ruby-rspec.rb
+++ b/lib/selective-ruby-rspec.rb
@@ -2,6 +2,7 @@
 
 require "zeitwerk"
 require "rspec/core"
+require "#{__dir__}/selective/ruby/rspec/version"
 
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.inflector.inflect("rspec" => "RSpec")


### PR DESCRIPTION
The VERSION constant doesn't follow the same naming convention that zeitwerk expects, so we need to explicitly require it.

This hasn't been a problem until now because we haven't used the VERSION constant outside of the gemspec.

It's now used in the RunnerWrapper#wrapper_version method.

Interestingly the absence of the require statement wasn't causing tests to fail locally. It does cause trouble on on core specs, though. See: https://github.com/selectiveci/selective-ruby-core/actions/runs/7366049397/job/20047925817