### PR TITLE
Give batches of test cases to RSpec to reduce filtering overhead

### DIFF
--- a/lib/selective/ruby/rspec/formatter.rb
+++ b/lib/selective/ruby/rspec/formatter.rb
@@ -1,0 +1,25 @@
+module Selective
+  module Ruby
+    module RSpec
+      class Formatter
+        ::RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending
+
+        def initialize(...); end
+
+        def self.callback=(callback)
+          @callback = callback
+        end
+
+        def self.callback
+          @callback
+        end
+        
+        %i(example_passed example_failed example_pending).each do |method|
+          define_method(method) do |notification|
+            self.class.callback.call(notification.example)
+          end
+        end
+      end
+    end
+  end
+end

--- a/selective-ruby-rspec.gemspec
+++ b/selective-ruby-rspec.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency("zeitwerk", "~> 2.6.12")
-  spec.add_dependency("selective-ruby-core")
+  spec.add_dependency("selective-ruby-core", ">= 0.2.2")
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/selective/ruby/rspec/formatter_spec.rb
+++ b/spec/selective/ruby/rspec/formatter_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Selective::Ruby::RSpec::Formatter do
+  class TestClass < described_class; end;
+
+  let(:formatter) { TestClass.new(nil) }
+  let(:example) { double('example') }
+  let(:notification) { double('notification', example: example) }
+  let(:callback) { double }
+
+  %i(example_passed example_failed example_pending).each do |method|
+    describe "##{method}" do
+      before do
+        TestClass.callback = callback
+        allow(callback).to receive(:call)
+        formatter.send(method, notification)
+      end
+
+      it 'calls the callback with the notification example' do
+        expect(callback).to have_received(:call).with(notification.example)
+      end
+    end
+  end
+end

--- a/spec/selective/ruby/rspec/runner_wrapper_spec.rb
+++ b/spec/selective/ruby/rspec/runner_wrapper_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Selective::Ruby::RSpec::RunnerWrapper do
-  let(:runner_wrapper) { dirty_dirty_unprivate_class(described_class).new(args) }
+  let(:runner_wrapper) { dirty_dirty_unprivate_class(described_class).new(args, example_callback) }
+  let(:example_callback) { ->(example) {} }
   let(:rspec_runner) { instance_double(::RSpec::Core::Runner, setup: nil) }
   let(:args) { [] }
 
@@ -11,8 +12,26 @@ RSpec.describe Selective::Ruby::RSpec::RunnerWrapper do
 
   before do
     allow(Selective::Ruby::RSpec::Monkeypatches).to receive(:apply)
+    allow(Selective::Ruby::RSpec::Formatter).to receive(:callback=)
     allow(::RSpec).to receive(:configure)
     allow(::RSpec::Core::Runner).to receive(:new).and_return(rspec_runner)
+    allow(runner_wrapper).to receive(:ensure_formatter)
+  end
+
+  describe '.initialize' do
+    before { runner_wrapper }
+    
+    it 'applies monkeypatches' do
+      expect(Selective::Ruby::RSpec::Monkeypatches).to have_received(:apply)
+    end
+
+    it 'sets the example_callback' do
+      expect(runner_wrapper.example_callback).to eq(example_callback)
+    end
+
+    it 'sets the formatter callback' do
+      expect(Selective::Ruby::RSpec::Formatter).to have_received(:callback=).with(Method)
+    end
   end
 
   describe "#manifest" do


### PR DESCRIPTION
This significantly reduces the overhead that selective adds to the test process.

Previously we were giving RSpec one example at a time. What we learned is that there is a good bit of overhead inside of RSpec relating to applying filters when you're targeting specific examples. By giving RSpec batches we can cut the overhead down quite a bit.

With this change, running an RSpec suite serially in a single process with and without Selective should complete in about the same about of time.