### PR TITLE
Pre-set RSpec's filtered examples (optimize performance)

### DIFF
--- a/lib/selective/ruby/rspec/monkeypatches.rb
+++ b/lib/selective/ruby/rspec/monkeypatches.rb
@@ -97,6 +97,16 @@ module Selective
             super
             @example_map = {}
           end
+
+          def prepare_example_filtering
+            @filtered_examples = Hash.new do |hash, group|
+              hash[group] = if ::RSpec.configuration.dry_run?
+                filter_manager.prune(group.examples)
+              else
+                []
+              end
+            end
+          end
         end
 
         module Runner
@@ -106,7 +116,7 @@ module Selective
         module Example
           def initialize(*args)
             super
-            ::RSpec.world.example_map[id] = example_group.parent_groups.last
+            ::RSpec.world.example_map[id] = self
           end
 
           def run(*args)

--- a/spec/selective/ruby/rspec/runner_wrapper_spec.rb
+++ b/spec/selective/ruby/rspec/runner_wrapper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Selective::Ruby::RSpec::RunnerWrapper do
     allow(Selective::Ruby::RSpec::Formatter).to receive(:callback=)
     allow(::RSpec).to receive(:configure)
     allow(::RSpec::Core::Runner).to receive(:new).and_return(rspec_runner)
-    allow(runner_wrapper).to receive(:ensure_formatter)
+    allow(runner_wrapper).to receive(:apply_formatter)
   end
 
   describe '.initialize' do


### PR DESCRIPTION
RSpec's filtering mechanism has a significant performance overhead. This commit pre-sets the filtered examples before running the tests to avoid this overhead.