### PR TITLE
Fix bug causing test failures when reconnect occurs

### DIFF
--- a/lib/selective/ruby/rspec/formatter.rb
+++ b/lib/selective/ruby/rspec/formatter.rb
@@ -6,17 +6,20 @@ module Selective
 
         def initialize(...); end
 
-        def self.callback=(callback)
-          @callback = callback
+        def self.runner_wrapper=(runner_wrapper)
+          @runner_wrapper = runner_wrapper
         end
 
-        def self.callback
-          @callback
+        def self.runner_wrapper
+          @runner_wrapper
         end
         
         %i(example_passed example_failed example_pending).each do |method|
           define_method(method) do |notification|
-            self.class.callback.call(notification.example)
+            self.class.runner_wrapper.report_example(notification.example)
+          rescue Selective::Ruby::Core::ConnectionLostError
+            ::RSpec.world.wants_to_quit = true
+            self.class.runner_wrapper.remove_test_case_result(notification.example.id)
           end
         end
       end

--- a/spec/selective/ruby/rspec/formatter_spec.rb
+++ b/spec/selective/ruby/rspec/formatter_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe Selective::Ruby::RSpec::Formatter do
   let(:formatter) { TestClass.new(nil) }
   let(:example) { double('example') }
   let(:notification) { double('notification', example: example) }
-  let(:callback) { double }
+  let(:runner_wrapper) { double }
 
   %i(example_passed example_failed example_pending).each do |method|
     describe "##{method}" do
       before do
-        TestClass.callback = callback
-        allow(callback).to receive(:call)
+        TestClass.runner_wrapper = runner_wrapper
+        allow(runner_wrapper).to receive(:report_example)
         formatter.send(method, notification)
       end
 
       it 'calls the callback with the notification example' do
-        expect(callback).to have_received(:call).with(notification.example)
+        expect(runner_wrapper).to have_received(:report_example).with(notification.example)
       end
     end
   end

--- a/spec/selective/ruby/rspec/runner_wrapper_spec.rb
+++ b/spec/selective/ruby/rspec/runner_wrapper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Selective::Ruby::RSpec::RunnerWrapper do
 
   before do
     allow(Selective::Ruby::RSpec::Monkeypatches).to receive(:apply)
-    allow(Selective::Ruby::RSpec::Formatter).to receive(:callback=)
+    allow(Selective::Ruby::RSpec::Formatter).to receive(:runner_wrapper=)
     allow(::RSpec).to receive(:configure)
     allow(::RSpec::Core::Runner).to receive(:new).and_return(rspec_runner)
     allow(runner_wrapper).to receive(:apply_formatter)
@@ -30,7 +30,7 @@ RSpec.describe Selective::Ruby::RSpec::RunnerWrapper do
     end
 
     it 'sets the formatter callback' do
-      expect(Selective::Ruby::RSpec::Formatter).to have_received(:callback=).with(Method)
+      expect(Selective::Ruby::RSpec::Formatter).to have_received(:runner_wrapper=).with(runner_wrapper)
     end
   end
 
@@ -79,11 +79,11 @@ RSpec.describe Selective::Ruby::RSpec::RunnerWrapper do
     end
   end
 
-  describe "#remove_failed_test_case_result" do
+  describe "#remove_test_case_result" do
     it "removes failed test cases" do
       ::RSpec.world.reporter.failed_examples << meta_example
       ::RSpec.world.reporter.examples << meta_example
-      runner_wrapper.remove_failed_test_case_result(meta_example.id)
+      runner_wrapper.remove_test_case_result(meta_example.id)
     end
   end
 


### PR DESCRIPTION
This regression happened when we implemented the formatter. Because RSpec is calling the formatter methods, we need to ensure we handle connection errors.