### PR TITLE
Fix retry when connection lost

### DIFF
--- a/lib/selective/ruby/rspec/formatter.rb
+++ b/lib/selective/ruby/rspec/formatter.rb
@@ -19,6 +19,7 @@ module Selective
             self.class.runner_wrapper.report_example(notification.example)
           rescue Selective::Ruby::Core::ConnectionLostError
             ::RSpec.world.wants_to_quit = true
+            self.class.runner_wrapper.connection_lost = true
             self.class.runner_wrapper.remove_test_case_result(notification.example.id)
           end
         end

--- a/lib/selective/ruby/rspec/runner_wrapper.rb
+++ b/lib/selective/ruby/rspec/runner_wrapper.rb
@@ -8,6 +8,7 @@ module Selective
         class TestManifestError < StandardError; end
 
         attr_reader :rspec_runner, :config, :example_callback
+        attr_accessor :connection_lost
 
         FRAMEWORK = "rspec"
         DEFAULT_SPEC_PATH = "./spec"
@@ -49,6 +50,10 @@ module Selective
           ensure_test_phase
           configure(test_case_ids)
           rspec_runner.run_specs(optimize_test_filtering(test_case_ids).to_a)
+          if connection_lost
+            self.connection_lost = false
+            raise Selective::Ruby::Core::ConnectionLostError
+          end
         end
 
         def exec


### PR DESCRIPTION
This fixes a bug where retries were broken.

It's important that we re-raise the ConnectionLostError so that the controller can properly reconnect to the back end.