### PR TITLE
Use `RSpec::Core::Runner#exit_code` to determine exit status

### DIFF
--- a/lib/selective/ruby/rspec/runner_wrapper.rb
+++ b/lib/selective/ruby/rspec/runner_wrapper.rb
@@ -75,7 +75,7 @@ module Selective
         end
 
         def exit_status
-          ::RSpec.world.reporter.failed_examples.any? ? 1 : 0
+          rspec_runner.exit_code(::RSpec.world.reporter.failed_examples.none?)
         end
 
         def finish

--- a/lib/selective/ruby/rspec/runner_wrapper.rb
+++ b/lib/selective/ruby/rspec/runner_wrapper.rb
@@ -75,7 +75,7 @@ module Selective
         end
 
         def exit_status
-          if Gem::Version.new(::RSpec::Core::Version::STRING) >= Gem::Version.new("3.9")
+          if Gem::Version.new(::RSpec::Core::Version::STRING) >= Gem::Version.new("3.10")
             rspec_runner.exit_code(::RSpec.world.reporter.failed_examples.none?)
           else
             return ::RSpec.world.reporter.exit_early(rspec_runner.configuration.failure_exit_code) if ::RSpec.world.wants_to_quit

--- a/lib/selective/ruby/rspec/runner_wrapper.rb
+++ b/lib/selective/ruby/rspec/runner_wrapper.rb
@@ -75,7 +75,13 @@ module Selective
         end
 
         def exit_status
-          rspec_runner.exit_code(::RSpec.world.reporter.failed_examples.none?)
+          if Gem::Version.new(::RSpec::Core::Version::STRING) >= Gem::Version.new("3.9")
+            rspec_runner.exit_code(::RSpec.world.reporter.failed_examples.none?)
+          else
+            return ::RSpec.world.reporter.exit_early(rspec_runner.configuration.failure_exit_code) if ::RSpec.world.wants_to_quit
+
+            ::RSpec.world.reporter.failed_examples.any? ? 1 : 0
+          end
         end
 
         def finish


### PR DESCRIPTION
We should be using this method because it takes non_example_failure into account.

Additionally, it allows us to support use-cases where folks may be monkeying with the exit_code method.