### PR TITLE
Pin RWX and Semaphore Ruby to 3.4.5

### DIFF
--- a/.rwx/push.yml
+++ b/.rwx/push.yml
@@ -3,6 +3,9 @@ on:
     push:
       init:
         commit-sha: ${{ event.git.sha }}
+  cli:
+    init:
+      commit-sha: ${{ event.git.sha }}
 
 base:
   image: ubuntu:24.04
@@ -18,7 +21,7 @@ tasks:
   - key: ruby
     call: ruby/install 1.2.27
     with:
-      ruby-version: 4.0.3
+      ruby-version: 3.4.5
   - key: install-dependencies
     use: [code, ruby]
     run: bundle install

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ blocks:
         - name: Run RSpec tests
           parallelism: 2
           commands:
-            - sem-version ruby 4.0.3
+            - sem-version ruby 3.4.5
             - checkout
             - bundle install
             - bundle exec selective rspec


### PR DESCRIPTION
## Summary
- Drop Ruby from 4.0.3 to 3.4.5 in `.rwx/push.yml` and `.semaphore/semaphore.yml`. Pending new gem releases that add Ruby 4 compatibility.
- Add a `cli:` trigger to `.rwx/push.yml` so runs can be started locally via `rwx run` without needing a GitHub push event (auto-added by the RWX CLI on first local run).

## Test plan
- [ ] RWX run completes green on Ruby 3.4.5
- [ ] Semaphore run completes green on Ruby 3.4.5
- [ ] `rwx run .rwx/push.yml --wait` works locally without `--init` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)